### PR TITLE
Expand test coverage to cover all apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Collate ALL the Huntsville beers. Check out the project's [documentation](http:/
 
 ### Installing software
 
-- [Python 3.7](https://www.python.org/downloads/)
+- [Python 3.6](https://www.python.org/downloads/)
+  - NOTE: We're stuck using Python 3.6 until [Celery 5.0](https://github.com/celery/celery/issues/4500) is released.
 - [Docker](https://docs.docker.com/docker-for-mac/install/) (Download for your platform)
   - NOTE: if you intend to develop on Windows, you need to have Windows 10 Pro or Enterprise to be able to use Docker, and you have to have at least a somewhat recent CPU that supports Hyper-V. Any non-Atom CPU from the past 5 years should more than suffice. Also, it'll break VirtualBox. 😿
 

--- a/hsv_dot_beer/config/local.py
+++ b/hsv_dot_beer/config/local.py
@@ -11,7 +11,7 @@ class Local(Common):
     INSTALLED_APPS += ('django_nose',)
     TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
     NOSE_ARGS = [
-        BASE_DIR,
+        os.path.dirname(BASE_DIR),
         '-s',
         '--nologcapture',
         '--with-coverage',

--- a/hsv_dot_beer/config/local.py
+++ b/hsv_dot_beer/config/local.py
@@ -12,8 +12,6 @@ class Local(Common):
     TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
     NOSE_ARGS = [
         os.path.dirname(BASE_DIR),
-        '-s',
-        '--nologcapture',
         '--with-coverage',
         '--with-progressive',
         '--cover-package=hsv_dot_beer'


### PR DESCRIPTION
1. Update readme to suggest Python 3.6 instead of 3.7
2. Change the directory passed to nose to be the git repo root, not `hsv_dot_beer/`
3. Switch back to the nose default of capturing stdout and logging