### PR TITLE
Open up read-only access to all users

### DIFF
--- a/beers/test/test_views.py
+++ b/beers/test/test_views.py
@@ -22,7 +22,7 @@ class TestBeerStyleDetailTestCase(APITestCase):
         self.style = BeerStyleFactory.create(tags=self.tags)
 
         self.url = reverse('beerstyle-detail', kwargs={'pk': self.style.pk})
-        self.user = UserFactory()
+        self.user = UserFactory(is_staff=True)
         self.client.credentials(
             HTTP_AUTHORIZATION=f'Token {self.user.auth_token}')
 
@@ -69,7 +69,7 @@ class ManufacturerListTestCase(APITestCase):
         self.manufacturer = ManufacturerFactory()
 
         self.url = reverse('manufacturer-list')
-        self.user = UserFactory()
+        self.user = UserFactory(is_staff=True)
         self.client.credentials(
             HTTP_AUTHORIZATION=f'Token {self.user.auth_token}')
 
@@ -98,7 +98,7 @@ class ManufacturerDetailTestCase(APITestCase):
         self.url = reverse(
             'manufacturer-detail', kwargs={'pk': self.manufacturer.pk},
         )
-        self.user = UserFactory()
+        self.user = UserFactory(is_staff=True)
         self.client.credentials(
             HTTP_AUTHORIZATION=f'Token {self.user.auth_token}',
         )
@@ -119,7 +119,7 @@ class BeerDetailTestCase(APITestCase):
         self.url = reverse(
             'beer-detail', kwargs={'pk': self.beer.pk},
         )
-        self.user = UserFactory()
+        self.user = UserFactory(is_staff=True)
         self.client.credentials(
             HTTP_AUTHORIZATION=f'Token {self.user.auth_token}'
         )

--- a/events/test/test_views.py
+++ b/events/test/test_views.py
@@ -28,7 +28,7 @@ class TestEventListTestCase(APITestCase):
         self.event_data['venue_id'] = self.event.venue.id
         del self.event_data['venue']
         # last, create the user
-        self.user = UserFactory()
+        self.user = UserFactory(is_staff=True)
         self.client.credentials(
             HTTP_AUTHORIZATION=f'Token {self.user.auth_token}')
 
@@ -54,7 +54,7 @@ class TestEventDetailTestCase(APITestCase):
     def setUp(self):
         self.event = EventFactory()
         self.url = reverse('event-detail', kwargs={'pk': self.event.pk})
-        self.user = UserFactory()
+        self.user = UserFactory(is_staff=True)
         self.client.credentials(
             HTTP_AUTHORIZATION=f'Token {self.user.auth_token}')
 

--- a/hsv_dot_beer/config/common.py
+++ b/hsv_dot_beer/config/common.py
@@ -198,7 +198,7 @@ class Common(Configuration):
             'rest_framework.renderers.BrowsableAPIRenderer',
         ),
         'DEFAULT_PERMISSION_CLASSES': [
-            'rest_framework.permissions.IsAuthenticated',
+            'hsv_dot_beer.permissions.IsAdminOrReadOnly',
         ],
         'DEFAULT_AUTHENTICATION_CLASSES': (
             'rest_framework.authentication.SessionAuthentication',

--- a/hsv_dot_beer/permissions.py
+++ b/hsv_dot_beer/permissions.py
@@ -1,0 +1,10 @@
+from rest_framework.permissions import BasePermission, SAFE_METHODS
+
+
+class IsAdminOrReadOnly(BasePermission):
+    def has_permission(self, request, view):
+        user = request.user
+        # if the user is a staff user (i.e. can log into the admin page),
+        # they can do anything in the API.
+        # Otherwise, only let safe requests (e.g. GET, OPTIONS) through
+        return user.is_staff or request.method in SAFE_METHODS

--- a/hsv_dot_beer/test_permissions.py
+++ b/hsv_dot_beer/test_permissions.py
@@ -1,0 +1,59 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
+
+from beers.test.factories import BeerFactory
+from hsv_dot_beer.users.test.factories import UserFactory
+
+
+class AuthTestCase(APITestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.normal_user = UserFactory()
+        cls.staff_user = UserFactory(is_staff=True)
+        cls.beer = BeerFactory()
+        cls.url = reverse('beer-detail', kwargs={'pk': cls.beer.id})
+
+    def test_normal_user_get(self):
+        self.client.credentials(
+            HTTP_AUTHORIZATION=f'Token {self.normal_user.auth_token}')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_normal_user_patch(self):
+        self.client.credentials(
+            HTTP_AUTHORIZATION=f'Token {self.normal_user.auth_token}')
+        payload = {'name': 'foo'}
+
+        response = self.client.patch(self.url, payload)
+        self.assertEqual(
+            response.status_code, status.HTTP_403_FORBIDDEN, response.data)
+
+    def test_anon_get(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_anon_user_patch(self):
+        payload = {'name': 'foo'}
+
+        response = self.client.patch(self.url, payload)
+        self.assertEqual(
+            response.status_code, status.HTTP_403_FORBIDDEN, response.data)
+
+    def test_staff_user_get(self):
+        self.client.credentials(
+            HTTP_AUTHORIZATION=f'Token {self.staff_user.auth_token}')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_staff_user_patch(self):
+        self.client.credentials(
+            HTTP_AUTHORIZATION=f'Token {self.staff_user.auth_token}')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        payload = {'name': 'foo'}
+
+        response = self.client.patch(self.url, payload)
+        self.assertEqual(
+            response.status_code, status.HTTP_200_OK, response.data)

--- a/hsv_dot_beer/users/test/test_views.py
+++ b/hsv_dot_beer/users/test/test_views.py
@@ -21,16 +21,24 @@ class TestUserListTestCase(APITestCase):
         self.user_data = model_to_dict(UserFactory.build())
 
     def test_post_request_with_no_data_fails(self):
+        user = UserFactory(is_staff=True)
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {user.auth_token}')
         response = self.client.post(self.url, {})
         eq_(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_post_request_with_valid_data_succeeds(self):
+        user = UserFactory(is_staff=True)
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {user.auth_token}')
         response = self.client.post(self.url, self.user_data)
         eq_(response.status_code, status.HTTP_201_CREATED)
 
         user = User.objects.get(pk=response.data.get('id'))
         eq_(user.username, self.user_data.get('username'))
         ok_(check_password(self.user_data.get('password'), user.password))
+
+    def test_post_request_unauthorized(self):
+        response = self.client.post(self.url, self.user_data)
+        eq_(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
 class TestUserDetailTestCase(APITestCase):

--- a/hsv_dot_beer/users/views.py
+++ b/hsv_dot_beer/users/views.py
@@ -1,5 +1,5 @@
 from rest_framework import viewsets, mixins
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import IsAdminUser
 from .models import User
 from .permissions import IsUserOrReadOnly
 from .serializers import CreateUserSerializer, UserSerializer
@@ -23,4 +23,4 @@ class UserCreateViewSet(mixins.CreateModelMixin,
     """
     queryset = User.objects.all()
     serializer_class = CreateUserSerializer
-    permission_classes = (AllowAny,)
+    permission_classes = (IsAdminUser,)

--- a/taps/test/test_views.py
+++ b/taps/test/test_views.py
@@ -17,7 +17,7 @@ class TestTapDetailTestCase(APITestCase):
         self.tap = TapFactory(room=self.room)
 
         self.url = reverse('tap-detail', kwargs={'pk': self.tap.pk})
-        self.user = UserFactory()
+        self.user = UserFactory(is_staff=True)
         self.client.credentials(
             HTTP_AUTHORIZATION=f'Token {self.user.auth_token}')
 

--- a/venues/test/test_views.py
+++ b/venues/test/test_views.py
@@ -20,7 +20,7 @@ class TestVenueListTestCase(APITestCase):
     def setUp(self):
         self.url = reverse('venue-list')
         self.venue_data = model_to_dict(VenueFactory.build())
-        self.user = UserFactory()
+        self.user = UserFactory(is_staff=True)
         self.client.credentials(
             HTTP_AUTHORIZATION=f'Token {self.user.auth_token}')
 
@@ -45,7 +45,7 @@ class TestVenueDetailTestCase(APITestCase):
     def setUp(self):
         self.venue = VenueFactory()
         self.url = reverse('venue-detail', kwargs={'pk': self.venue.pk})
-        self.user = UserFactory()
+        self.user = UserFactory(is_staff=True)
         self.client.credentials(
             HTTP_AUTHORIZATION=f'Token {self.user.auth_token}')
 
@@ -117,7 +117,7 @@ class RoomListTestCase(APITestCase):
     def setUp(self):
         self.url = reverse('room-list')
         self.venue = VenueFactory()
-        self.user = UserFactory()
+        self.user = UserFactory(is_staff=True)
         self.room_data = {
             'venue_id': self.venue.id,
             'name': 'test room',
@@ -149,7 +149,7 @@ class RoomDetailTestCase(APITestCase):
         self.venue = VenueFactory()
         self.room = Room.objects.create(venue=self.venue, name='foo')
         self.url = reverse('room-detail', kwargs={'pk': self.room.pk})
-        self.user = UserFactory()
+        self.user = UserFactory(is_staff=True)
         self.client.credentials(
             HTTP_AUTHORIZATION=f'Token {self.user.auth_token}')
 


### PR DESCRIPTION
New access control rules:

1. Anybody can read anything that's exposed in the API
2. Only staff users (those who can access the admin page) can
   write to anything.

Fixes #13.