### PR TITLE
Stop looking up the beer with defaults

### DIFF
--- a/tap_list_providers/base.py
+++ b/tap_list_providers/base.py
@@ -133,7 +133,6 @@ class BaseTapListProvider():
                 beer = Beer.objects.get(
                     Q(name=name) | Q(alternate_names__name=name),
                     manufacturer=manufacturer,
-                    **defaults,
                 )
             except Beer.DoesNotExist:
                 beer = Beer.objects.create(


### PR DESCRIPTION
That way, if a beer has metadata that doesn't match but names
conflict, we won't get an integrity error.