### PR TITLE
Work around Yellowhammer reformatting its menu

### DIFF
--- a/tap_list_providers/parsers/untappd.py
+++ b/tap_list_providers/parsers/untappd.py
@@ -31,8 +31,8 @@ class UntappdParser(BaseTapListProvider):
         self.location_url = None
         if location and theme:
             self.location_url = self.URL.format(location, theme)
-
-        self.categories = cats or []
+        LOG.debug('categories: %s', cats)
+        self.categories = [i.casefold() for i in cats] if cats else []
         super().__init__()
 
     def fetch_data(self):
@@ -42,7 +42,10 @@ class UntappdParser(BaseTapListProvider):
         return data
 
     def handle_venue(self, venue):
-        self.categories = venue.api_configuration.untappd_categories
+        self.categories = [
+            i.casefold() for i in venue.api_configuration.untappd_categories
+        ]
+        LOG.debug('Categories: %s', self.categories)
         self.location_url = self.URL.format(
             venue.api_configuration.untappd_location,
             venue.api_configuration.untappd_theme,
@@ -120,8 +123,11 @@ class UntappdParser(BaseTapListProvider):
 
         for element in info_elements:
             text = element.find('div', {'class': 'section-name'}).text
-            if text in self.categories:
+            if text.casefold() in self.categories:
+                LOG.debug('Adding tap list %s', text)
                 self.taplists.append(element)
+            else:
+                LOG.debug('Ignoring tap list %s', text)
 
     def parse_style(self, style):
         if '-' in style:
@@ -234,7 +240,9 @@ class UntappdParser(BaseTapListProvider):
     def taps(self):
         ret = []
         for taplist in self.taplists:
+            LOG.debug('Opening tap list')
             entries = taplist.find_all('div', {'class': 'beer'})
+            LOG.debug('Found %s entries', len(entries))
             updated = None
             menus = self.soup.find_all('div', {'class': 'menu-info'})
             for menu in menus:

--- a/venues/fixtures/venues.json
+++ b/venues/fixtures/venues.json
@@ -568,7 +568,7 @@
         "digital_pour_location_number": null,
         "untappd_location": 5949,
         "untappd_theme": 20074,
-        "untappd_categories": "[\"YEAR-ROUND\", \"SEASONALS\", \"Beer\"]",
+        "untappd_categories": "[\"Year-Round Beer\", \"Beer\"]",
         "taphunter_location": ""
     }
 },


### PR DESCRIPTION
Fixes #98 by:

1. Making the category comparison case-insensitive
2. Changing the category comparison to use the `section` div heading rather than the `menu-title` h1.