### PR TITLE
Silence a couple warnings and catch redis limit in parsing code

### DIFF
--- a/tap_list_providers/base.py
+++ b/tap_list_providers/base.py
@@ -162,20 +162,24 @@ class BaseTapListProvider():
                         # these don't have to be unique
                         if beer.logo_url:
                             if venue and venue.tap_list_provider == 'taphunter':
-                                LOG.info(
-                                    'Not trusting beer logo for %s from TapHunter'
-                                    ' because TH does not distinguish between '
-                                    'beer and brewery logos', beer
-                                )
+                                if beer.logo_url != value:
+                                    LOG.info(
+                                        'Not trusting beer logo for %s from '
+                                        'TapHunter because TH does not '
+                                        'distinguish between beer and brewery '
+                                        'logos', beer
+                                    )
                                 continue
                             found = False
                             for target, provider in PROVIDER_BREWERY_LOGO_STRINGS.items():
                                 if target in value:
-                                    LOG.info(
-                                        'Not overwriting logo for beer %s (%s) with brewery logo'
-                                        ' from %s',
-                                        beer, beer.logo_url, provider,
-                                    )
+                                    if beer.logo_url != value:
+                                        LOG.info(
+                                            'Not overwriting logo for beer %s '
+                                            '(%s) with brewery logo'
+                                            ' from %s',
+                                            beer, beer.logo_url, provider,
+                                        )
                                     found = True
                                     break
                             if found:

--- a/tap_list_providers/base.py
+++ b/tap_list_providers/base.py
@@ -157,48 +157,46 @@ class BaseTapListProvider():
             for field, value in defaults.items():
                 # instead of using update_or_create(), only update fields *if*
                 # they're set in `defaults`
-                if value:
-                    if field == 'logo_url':
-                        # these don't have to be unique
-                        if beer.logo_url:
-                            if venue and venue.tap_list_provider == 'taphunter':
-                                if beer.logo_url != value:
-                                    LOG.info(
-                                        'Not trusting beer logo for %s from '
-                                        'TapHunter because TH does not '
-                                        'distinguish between beer and brewery '
-                                        'logos', beer
-                                    )
-                                continue
-                            found = False
-                            for target, provider in PROVIDER_BREWERY_LOGO_STRINGS.items():
-                                if target in value:
-                                    if beer.logo_url != value:
-                                        LOG.info(
-                                            'Not overwriting logo for beer %s '
-                                            '(%s) with brewery logo'
-                                            ' from %s',
-                                            beer, beer.logo_url, provider,
-                                        )
-                                    found = True
-                                    break
-                            if found:
-                                continue
-                    elif field.endswith('_url'):
-                        if Beer.objects.exclude(id=beer.id).filter(
-                            **{field: value}
-                        ).exists():
-                            LOG.warning(
-                                'skipping updating %s (%s) for %s (PK %s)'
-                                ' because it would conflict',
-                                field, value, beer.name, beer.id,
+                if not value or getattr(beer, field) == value:
+                    # it's either unset or is already set to this value
+                    continue
+                if field == 'logo_url':
+                    # these don't have to be unique
+                    if beer.logo_url:
+                        if venue and venue.tap_list_provider == 'taphunter':
+                            LOG.info(
+                                'Not trusting beer logo for %s from TapHunter'
+                                ' because TH does not distinguish between '
+                                'beer and brewery logos', beer
                             )
                             continue
-                    saved_value = getattr(beer, field)
-                    if value != saved_value:
-                        # TODO mark as unmoderated
-                        setattr(beer, field, value)
-                        needs_update = True
+                        found = False
+                        for target, provider in PROVIDER_BREWERY_LOGO_STRINGS.items():
+                            if target in value:
+                                LOG.info(
+                                    'Not overwriting logo for beer %s (%s) with brewery logo'
+                                    ' from %s',
+                                    beer, beer.logo_url, provider,
+                                )
+                                found = True
+                                break
+                        if found:
+                            continue
+                elif field.endswith('_url'):
+                    if Beer.objects.exclude(id=beer.id).filter(
+                        **{field: value}
+                    ).exists():
+                        LOG.warning(
+                            'skipping updating %s (%s) for %s (PK %s)'
+                            ' because it would conflict',
+                            field, value, beer.name, beer.id,
+                        )
+                        continue
+                saved_value = getattr(beer, field)
+                if value != saved_value:
+                    # TODO mark as unmoderated
+                    setattr(beer, field, value)
+                    needs_update = True
         if manufacturer.logo_url and not beer.logo_url:
             beer.logo_url = manufacturer.logo_url
             needs_update = True


### PR DESCRIPTION
1. Don't bother validating URL fields if it's already set to the same value that's passed in to `look_up_beer()`
2. If we run into the heroku free redis limit while parsing beers, fall back to looking up untappd metadata synchronously.