### PR TITLE
Scale back workers to 4 processes

### DIFF
--- a/bin/entry-point.sh
+++ b/bin/entry-point.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 gunicorn hsv_dot_beer.wsgi --log-file - &
-celery -A hsv_dot_beer worker -l info -c 4 --beat --scheduler django_celery_beat.schedulers:DatabaseScheduler -O fair
+celery -A hsv_dot_beer worker -l info -c 2 --beat --scheduler django_celery_beat.schedulers:DatabaseScheduler -O fair

--- a/bin/entry-point.sh
+++ b/bin/entry-point.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 gunicorn hsv_dot_beer.wsgi --log-file - &
-celery -A hsv_dot_beer worker -l info  --beat --scheduler django_celery_beat.schedulers:DatabaseScheduler -O fair
+celery -A hsv_dot_beer worker -l info -c 4 --beat --scheduler django_celery_beat.schedulers:DatabaseScheduler -O fair


### PR DESCRIPTION
The heroku VM has 8 cores. Let's not use them all in the hopes of
saving RAM.

If this still isn't enough, we can go back to 2.