### PR TITLE
Delete unused Stem and Stein taps

### DIFF
--- a/tap_list_providers/parsers/stemandstein.py
+++ b/tap_list_providers/parsers/stemandstein.py
@@ -173,6 +173,8 @@ class StemAndSteinParser(BaseTapListProvider):
         existing_taps = {
             i.tap_number: i for i in venue.taps.all()
         }
+        LOG.debug('existing taps %s', existing_taps)
+        taps_hit = []
         for tap_number, beer in taps.items():
             self.fill_in_beer_details(beer)
             try:
@@ -184,3 +186,10 @@ class StemAndSteinParser(BaseTapListProvider):
                 )
             tap.beer = beer
             tap.save()
+            taps_hit.append(tap.tap_number)
+        LOG.debug('Deleting all taps except %s', taps_hit)
+        Tap.objects.filter(
+            venue=venue,
+        ).exclude(
+            tap_number__in=taps_hit,
+        ).delete()

--- a/tap_list_providers/test/test_stemandstein.py
+++ b/tap_list_providers/test/test_stemandstein.py
@@ -61,6 +61,10 @@ class CommandsTestCase(TestCase):
         self.assertEqual(Venue.objects.count(), 1)
         self.assertFalse(Beer.objects.exists())
         self.assertFalse(Manufacturer.objects.exists())
+        deleted_tap = Tap.objects.create(
+            venue=self.venue,
+            tap_number=3000,
+        )
         for dummy in range(2):
             # running twice to make sure we're not double-creating
             args = []
@@ -98,6 +102,7 @@ class CommandsTestCase(TestCase):
             price = prices[0]
             self.assertEqual(price.price, 8)
             self.assertEqual(price.serving_size.volume_oz, 10)
+            self.assertFalse(Tap.objects.filter(id=deleted_tap.id).exists())
 
     def test_guess_manufacturer_good_people(self):
         mfg_names = [


### PR DESCRIPTION
Because The Stem and Stein doesn't include tap numbers in its site,
we automatically assign them taps 1 through _N_. Because _N_ is
variable (currently at 10, max seen is 18), we should make sure
we drop unused taps at the end of each processing run.

Otherwise, we have stale data (e.g. beers that were removed weeks
ago).

Fixes #219.