### PR TITLE
Save prices when merging beers

### DIFF
--- a/beers/models.py
+++ b/beers/models.py
@@ -207,6 +207,22 @@ class Beer(models.Model):
         with transaction.atomic():
             Tap.objects.filter(beer=other).update(beer=self)
             BeerAlternateName.objects.filter(beer=other).update(beer=self)
+            try:
+                with transaction.atomic():
+                    BeerPrice.objects.filter(beer=other).update(beer=self)
+            except IntegrityError:
+                LOG.warning('Duplicate prices detected for %s', self)
+                prices_updated = BeerPrice.objects.filter(beer=other).exclude(
+                    venue__in=models.Subquery(
+                        BeerPrice.objects.filter(beer=self).values('venue')
+                    ),
+                ).update(beer=self)
+                prices_deleted = BeerPrice.objects.filter(beer=other).delete()
+                LOG.info(
+                    'Updated %s prices and deleted %s prices',
+                    prices_updated,
+                    prices_deleted,
+                )
             excluded_fields = {
                 'name' 'in_production', 'automatic_updates_blocked',
                 'manufacturer', 'id', 'time_first_seen',

--- a/beers/test/test_merge.py
+++ b/beers/test/test_merge.py
@@ -3,37 +3,87 @@ import datetime
 from django.test import TestCase
 from pytz import UTC
 
-from beers.models import Beer, Manufacturer, BeerAlternateName, ManufacturerAlternateName
+from beers.models import (
+    Beer, Manufacturer, BeerAlternateName, ManufacturerAlternateName, BeerPrice,
+    ServingSize,
+)
 from taps.test.factories import TapFactory
+from venues.test.factories import VenueFactory
 
 from .factories import BeerFactory, ManufacturerFactory
 
 
 class BeerTestCase(TestCase):
+    def setUp(self):
+        self.manufacturer = ManufacturerFactory()
+        self.new_time = UTC.localize(datetime.datetime(2018, 4, 3, 6, 2))
+        self.other_time = self.new_time + datetime.timedelta(days=30)
+        self.beer1 = BeerFactory(
+            manufacturer=self.manufacturer, untappd_url='http://localhost/123456',
+            color_srm=None, time_first_seen=self.other_time,
+        )
+        self.beer2 = BeerFactory(
+            manufacturer=self.manufacturer, color_srm=55, stem_and_stein_pk=551,
+            time_first_seen=self.new_time,
+        )
+        self.tap = TapFactory(beer=self.beer2)
+        self.venue2 = self.tap.venue
+        self.venue1 = VenueFactory()
+        self.serving_size = ServingSize.objects.create(name='foo', volume_oz=12)
 
     def test_merge(self):
-        manufacturer = ManufacturerFactory()
-        new_time = UTC.localize(datetime.datetime(2018, 4, 3, 6, 2))
-        other_time = new_time + datetime.timedelta(days=30)
-        beer1 = BeerFactory(
-            manufacturer=manufacturer, untappd_url='http://localhost/123456',
-            color_srm=None, time_first_seen=other_time,
-        )
-        beer2 = BeerFactory(
-            manufacturer=manufacturer, color_srm=55, stem_and_stein_pk=551,
-            time_first_seen=new_time,
-        )
-        tap = TapFactory(beer=beer2)
-        beer1.merge_from(beer2)
-        self.assertEqual(beer1.color_srm, beer2.color_srm)
-        tap.refresh_from_db()
-        self.assertEqual(tap.beer, beer1)
-        self.assertFalse(Beer.objects.filter(id=beer2.id).exists())
+        self.beer1.merge_from(self.beer2)
+        self.assertEqual(self.beer1.color_srm, self.beer2.color_srm)
+        self.tap.refresh_from_db()
+        self.assertEqual(self.tap.beer, self.beer1)
+        self.assertFalse(Beer.objects.filter(id=self.beer2.id).exists())
         self.assertTrue(BeerAlternateName.objects.filter(
-            name=beer2.name, beer=beer1,
+            name=self.beer2.name, beer=self.beer1,
         ).exists())
-        self.assertEqual(tap.beer.time_first_seen, new_time)
-        self.assertEqual(tap.beer.stem_and_stein_pk, 551)
+        self.assertEqual(self.tap.beer.time_first_seen, self.new_time)
+        self.assertEqual(self.tap.beer.stem_and_stein_pk, 551)
+
+    def test_preserve_prices_no_overlap(self):
+        BeerPrice.objects.create(
+            beer=self.beer1,
+            venue=self.venue1,
+            price=15,
+            serving_size=self.serving_size,
+        )
+        BeerPrice.objects.create(
+            beer=self.beer2,
+            venue=self.venue2,
+            price=10,
+            serving_size=self.serving_size,
+        )
+        self.beer1.merge_from(self.beer2)
+        self.assertEqual(BeerPrice.objects.filter(beer=self.beer1).count(), 2)
+
+    def test_preserve_prices_overlap(self):
+        BeerPrice.objects.create(
+            beer=self.beer1,
+            venue=self.venue2,
+            price=15,
+            serving_size=self.serving_size,
+        )
+        BeerPrice.objects.create(
+            beer=self.beer2,
+            venue=self.venue2,
+            price=10,
+            serving_size=self.serving_size,
+        )
+        other_size = ServingSize.objects.create(name='bar', volume_oz=16)
+        BeerPrice.objects.create(
+            beer=self.beer2,
+            venue=self.venue2,
+            price=20,
+            serving_size=other_size,
+        )
+        self.beer1.merge_from(self.beer2)
+        # Because we have an overlap in one unique condition (beer + venue + size),
+        # we are going to take the safest route possible and ignore both of the
+        # prices from beer2 for venue2.
+        self.assertEqual(BeerPrice.objects.filter(beer=self.beer1).count(), 1)
 
 
 class ManufacturerTestCase(TestCase):


### PR DESCRIPTION
If two beers to be merged have the same venue + size combo, take
the most cautious route possible and discard prices from the other
beer for that venue.

Any issues with inconsistent data will resolve themselves within
an hour of moderation anyway.

Fixes #239.