### PR TITLE
Allow filtering beers by venue slug

### DIFF
--- a/beers/filters.py
+++ b/beers/filters.py
@@ -68,5 +68,6 @@ class BeerFilterSet(FilterSet):
             'style__alternate_names__name': DEFAULT_STRING_FILTER_OPERATORS,
             'search': ['exact'],
             'on_tap': ['exact'],
+            'taps__venue__slug': DEFAULT_STRING_FILTER_OPERATORS,
         }
         model = models.Beer


### PR DESCRIPTION
`/api/v1/beers/?taps__venue__slug=otbx` to get beers at OTBX, for example.

Fixes #236 in a band-aid way until django-rest-framework-filters 1.0
comes out.