### PR TITLE
Improve Azure pipeline runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,11 +7,11 @@ trigger:
 - master
 
 pool:
-  vmImage: 'Ubuntu-16.04'
+  vmImage: 'Ubuntu-18.04'
 strategy:
   matrix:
-    Python36:
-      PYTHON_VERSION: '3.6'
+    Python37:
+      PYTHON_VERSION: '3.7'
   maxParallel: 3
 
 steps:
@@ -37,9 +37,14 @@ steps:
       print('##vso[task.setvariable variable=projectRoot]{}'.format(project_location))
 
 - script: |
-    docker-compose run --rm web bash -c 'export PIPENV_COLORBLIND=1; pipenv install --dev && pipenv run pip install unittest-xml-reporting && pipenv run flake8 && pipenv run python manage.py test --testrunner xmlrunner.extra.djangotestrunner.XMLTestRunner --no-input'
+    docker-compose run --rm web bash -c 'export PIPENV_COLORBLIND=1; pipenv install --dev && pipenv run pip install unittest-xml-reporting && pipenv run flake8'
   condition: succeededOrFailed()
-  displayName: 'Run tests'
+  displayName: 'Run pep8'
+
+- script: |
+    docker-compose run --rm web bash -c 'export PIPENV_COLORBLIND=1; pipenv install --dev && pipenv run pip install unittest-xml-reporting && pipenv run python manage.py test --testrunner xmlrunner.extra.djangotestrunner.XMLTestRunner --no-input'
+  condition: succeededOrFailed()
+  displayName: 'Run Django tests'
 
 - task: PublishTestResults@2
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,12 +37,12 @@ steps:
       print('##vso[task.setvariable variable=projectRoot]{}'.format(project_location))
 
 - script: |
-    docker-compose run --rm web bash -c 'export PIPENV_COLORBLIND=1; pipenv install --dev && pipenv run pip install unittest-xml-reporting && pipenv run flake8'
+    docker-compose run --rm web bash -c 'export PIPENV_COLORBLIND=1; export PIPENV_NOSPIN=1; pipenv install --dev && pipenv run pip install unittest-xml-reporting && pipenv run flake8'
   condition: succeededOrFailed()
   displayName: 'Run pep8'
 
 - script: |
-    docker-compose run --rm web bash -c 'export PIPENV_COLORBLIND=1; pipenv install --dev && pipenv run pip install unittest-xml-reporting && pipenv run python manage.py test --testrunner xmlrunner.extra.djangotestrunner.XMLTestRunner --no-input'
+    docker-compose run --rm web bash -c 'export PIPENV_COLORBLIND=1; export PIPENV_NOSPIN=1; pipenv install --dev && pipenv run pip install unittest-xml-reporting && pipenv run python manage.py test --testrunner xmlrunner.extra.djangotestrunner.XMLTestRunner --no-input'
   condition: succeededOrFailed()
   displayName: 'Run Django tests'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ steps:
       print('Found Django project in', project_location)
       print('##vso[task.setvariable variable=projectRoot]{}'.format(project_location))
 
-- script: docker-compose run --rm web bash -c 'pip install flake8 && flake8'
+- script: bash -c 'pip install flake8 && flake8'
   condition: succeededOrFailed()
   displayName: 'Run pep8'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,8 +14,6 @@ strategy:
       PYTHON_VERSION: '3.7'
   maxParallel: 3
 
-container: ubuntu:18.04
-
 steps:
 - task: UsePythonVersion@0
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,8 +36,7 @@ steps:
       print('Found Django project in', project_location)
       print('##vso[task.setvariable variable=projectRoot]{}'.format(project_location))
 
-- script: |
-    docker-compose run --rm web bash -c 'export PIPENV_COLORBLIND=1; export PIPENV_NOSPIN=1; pipenv install --dev && pipenv run pip install unittest-xml-reporting && pipenv run flake8'
+- script: docker-compose run --rm web bash -c 'pip install flake8 && flake8'
   condition: succeededOrFailed()
   displayName: 'Run pep8'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,12 +7,14 @@ trigger:
 - master
 
 pool:
-  vmImage: 'Ubuntu-18.04'
+  vmImage: 'Ubuntu-16.04'
 strategy:
   matrix:
     Python37:
       PYTHON_VERSION: '3.7'
   maxParallel: 3
+
+container: ubuntu:18.04
 
 steps:
 - task: UsePythonVersion@0


### PR DESCRIPTION
1. Split pep8 and django tests into separate `script` blocks
2. Upgrade to python 3.7
3. Disable the pipenv spinner to hopefully make the logs way shorter
4. Don't use pipenv or docker for the pep8 run for speed