### PR TITLE
Work around manufacturer alternate name matching name

### DIFF
--- a/tap_list_providers/parsers/stemandstein.py
+++ b/tap_list_providers/parsers/stemandstein.py
@@ -95,10 +95,10 @@ class StemAndSteinParser(BaseTapListProvider):
             manufacturer = ' '.join(words[:index])
             if not use_contains:
                 try:
-                    return Manufacturer.objects.get(
+                    return Manufacturer.objects.filter(
                         Q(name__iexact=manufacturer) |
                         Q(alternate_names__name__iexact=manufacturer)
-                    )
+                    ).distinct().get()
                 except Manufacturer.DoesNotExist:
                     continue
             filter_str = 'icontains' if use_contains else 'istartswith'

--- a/tap_list_providers/test/test_stemandstein.py
+++ b/tap_list_providers/test/test_stemandstein.py
@@ -5,7 +5,7 @@ from django.core.management import call_command
 from django.test import TestCase
 import responses
 
-from beers.models import Beer, Manufacturer
+from beers.models import Beer, Manufacturer, ManufacturerAlternateName
 from beers.test.factories import ManufacturerFactory
 from venues.test.factories import VenueFactory
 from venues.models import Venue, VenueAPIConfiguration
@@ -144,3 +144,13 @@ class CommandsTestCase(TestCase):
         guessed = parser.guess_manufacturer('Goat Island Sipsey River Red Ale')
         self.assertEqual(guessed.name, 'Goat Island', guessed)
         self.assertIn(guessed, manufacturers)
+
+    def test_guess_manufacturer_back_forty(self):
+        mfg = ManufacturerFactory(name='Back Forty')
+        ManufacturerAlternateName.objects.bulk_create(
+            ManufacturerAlternateName(name=name, manufacturer=mfg)
+            for name in ['Back Forty', 'Back Forty Beer Co']
+        )
+        parser = StemAndSteinParser()
+        guessed = parser.guess_beer('Back Forty Truck Stop Honey Brown')
+        self.assertEqual(guessed.manufacturer, mfg)


### PR DESCRIPTION
If the manufacturer alternate name matched the manufacturer's
name exactly, this caused a `MultipleObjectsReturned` exception
to be raised.

This manifested in the form of Back Forty Truck Stop Honey causing
Stem and Stein parsing to crash because Back Forty had an alternate
name of `Back Forty`.

I already deleted the offending duplicate alternate name to get parsing working again, but this will be a more permanent fix.

Fixes #244.