### PR TITLE
Fix need to rebuild image every time tasks change

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       - postgres
       - redis
     build: ./
+    volumes:
+      - ./:/code
     command: >
       bash -c "pipenv run python wait_for_postgres.py &&
                pipenv run ./manage.py migrate &&


### PR DESCRIPTION
By copying the volume, we only need to restart the image rather
than rebuild it every time we change worker code.

Doesn't effect anything in prod but makes dev way easier.