### PR TITLE
Fix CORS regex to account for hyphens

### DIFF
--- a/hsv_dot_beer/config/production.py
+++ b/hsv_dot_beer/config/production.py
@@ -41,5 +41,7 @@ class Production(Common):
     )
 
     CORS_ORIGIN_REGEX_WHITELIST = [
-        r"^https://\w+\.herokuapp\.com$",
+        # while we're developing the nuxt.js frontend, heroku PR review apps
+        # are deployed at https://hsvdotbeer-nuxt-pr-NNN.herokuapp.com
+        r"^https:\/\/hsvdotbeer-nuxt-pr-\d+\.herokuapp\.com$",
     ]


### PR DESCRIPTION
`\w` is equivalent to `[a-zA-Z0-9_]`. Note that hyphens aren't
included.

Also go ahead and switch the regex to be more specific.

I think this does what #252 was trying to do.