### PR TITLE
Save beer ABV and brewery location if given from Stem & Stein

### DIFF
--- a/tap_list_providers/parsers/stemandstein.py
+++ b/tap_list_providers/parsers/stemandstein.py
@@ -146,6 +146,29 @@ class StemAndSteinParser(BaseTapListProvider):
         price = Decimal(pricing_div.text[1:])
         image_url = image_div.find('img').attrs['src']
         image_params = dict(parse_qsl(image_url.split('?')[-1]))
+        abv_div = jumbotron.find(
+            'div',
+            {
+                'style': 'color:slategray; font-size:18px;padding-left:20px',
+            },
+        )
+        if not beer.abv:
+            if 'ABV' in abv_div.text:
+                # ABV x.y% (a bunch of spaces) city, state
+                try:
+                    abv = Decimal(abv_div.text.split()[1][:-1])
+                except ValueError:
+                    LOG.warning('Invalid S&S ABV %s for beer %s', abv_div.text, beer)
+                else:
+                    LOG.info('Setting ABV for beer %s to %s%%', beer, abv)
+                    beer.abv = abv
+                    beer.save()
+        if not beer.manufacturer.location:
+            raw_text = abv_div.text.replace('&nbsp;', '')
+            percent_index = raw_text.index('%')
+            beer.manufacturer.location = raw_text[percent_index + 1:].strip()
+            LOG.info('Setting beer %s location to %s', beer, beer.manufacturer.location)
+            beer.manufacturer.save()
         try:
             color = self.html_parser.unescape(image_params['color'])
         except KeyError:

--- a/tap_list_providers/parsers/stemandstein.py
+++ b/tap_list_providers/parsers/stemandstein.py
@@ -160,14 +160,14 @@ class StemAndSteinParser(BaseTapListProvider):
                 except ValueError:
                     LOG.warning('Invalid S&S ABV %s for beer %s', abv_div.text, beer)
                 else:
-                    LOG.info('Setting ABV for beer %s to %s%%', beer, abv)
+                    LOG.debug('Setting ABV for beer %s to %s%%', beer, abv)
                     beer.abv = abv
                     beer.save()
         if not beer.manufacturer.location:
             raw_text = abv_div.text.replace('&nbsp;', '')
             percent_index = raw_text.index('%')
             beer.manufacturer.location = raw_text[percent_index + 1:].strip()
-            LOG.info('Setting beer %s location to %s', beer, beer.manufacturer.location)
+            LOG.debug('Setting beer %s location to %s', beer, beer.manufacturer.location)
             beer.manufacturer.save()
         try:
             color = self.html_parser.unescape(image_params['color'])

--- a/tap_list_providers/test/test_stemandstein.py
+++ b/tap_list_providers/test/test_stemandstein.py
@@ -1,5 +1,6 @@
 """Test the parsing of stem and stein data"""
 import os
+from decimal import Decimal
 
 from django.core.management import call_command
 from django.test import TestCase
@@ -78,13 +79,15 @@ class CommandsTestCase(TestCase):
             taps = Tap.objects.filter(
                 venue=self.venue, tap_number__in=[1, 17],
             ).select_related(
-                'beer__style',
+                'beer__style', 'beer__manufacturer',
             ).order_by('tap_number')
             tap = taps[0]
             self.assertTrue(
                 tap.beer.name.endswith('Space Blood Orange Cider'),
                 tap.beer.name,
             )
+            self.assertEqual(tap.beer.manufacturer.location, 'Sebastopol, CA')
+            self.assertEqual(tap.beer.abv, Decimal('6.9'))
             self.assertEqual(tap.beer.stem_and_stein_pk, 967)
             prices = list(tap.beer.prices.all())
             self.assertEqual(len(prices), 1)
@@ -97,6 +100,7 @@ class CommandsTestCase(TestCase):
                 tap.beer.name.endswith('Karmeliet'),
                 tap.beer.name,
             )
+            self.assertEqual(tap.beer.manufacturer.location, 'Belgium')
             prices = list(tap.beer.prices.all())
             self.assertEqual(len(prices), 1)
             price = prices[0]


### PR DESCRIPTION
It's relatively easy to parse, so let's save the ABV & brewery location if given.

Fixes #254 