### PR TITLE
Add beer logos

### DIFF
--- a/venues/fixtures/venues.json
+++ b/venues/fixtures/venues.json
@@ -148,7 +148,7 @@
         "untappd_url": null,
         "email": "",
         "phone_number": "",
-        "logo_url": "",
+        "logo_url": "https://untappd.akamaized.net/venuelogos/venue_56705_d99a0ed7_bg_176.png?v=1",
         "slug": "liquor-express",
         "on_downtown_craft_beer_trail": true,
         "latitude": "34.74135200",

--- a/venues/fixtures/venues.json
+++ b/venues/fixtures/venues.json
@@ -200,7 +200,7 @@
         "untappd_url": "https://untappd.com/v/the-open-bottle/8190315",
         "email": "",
         "phone_number": "2568018990",
-        "logo_url": "",
+        "logo_url": "https://lh3.googleusercontent.com/1uXqdbfP9x1fndqlwLBWYv5SxAOq5ne5bWBaxFRXwxKmji0O25W7weohMrlfX0haxFQKF3Uv-HnUf7AnTDMHCLE6eT_Qo_Y=s750",
         "slug": "open-bottle",
         "on_downtown_craft_beer_trail": false,
         "latitude": "34.75356000",


### PR DESCRIPTION
They're small and usable.

- Liquor Express
- Open Bottle

Addresses #251 