### PR TITLE
More logos

### DIFF
--- a/venues/fixtures/venues.json
+++ b/venues/fixtures/venues.json
@@ -70,7 +70,7 @@
         "untappd_url": null,
         "email": "",
         "phone_number": "2562707825",
-        "logo_url": "http://otbxhsv.com/wp-content/themes/otbx-wp/img/logo.png",
+        "logo_url": "http://otbxhsv.com/wp-content/themes/otbx-wp/dist/img/fb.png",
         "slug": "otbx",
         "on_downtown_craft_beer_trail": true,
         "latitude": "34.73339800",

--- a/venues/fixtures/venues.json
+++ b/venues/fixtures/venues.json
@@ -122,7 +122,7 @@
         "untappd_url": "https://untappd.com/v/whole-foods-market/3882150",
         "email": "",
         "phone_number": "2568013741",
-        "logo_url": "",
+        "logo_url": "https://www.wholefoodsmarket.com/sites/default/files/media/Whole%20Foods%20Logo_1.JPG",
         "slug": "whole-foods-hsv",
         "on_downtown_craft_beer_trail": false,
         "latitude": "34.71222600",


### PR DESCRIPTION
Now every logo is usable except for Stem & Stein, which doesn't host a valid (read: not white on transparent) logo anywhere.

Addresses #251.