### PR TITLE
Switch to django-bmemcached for the backend

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -28,6 +28,8 @@ celery = {extras = ["redis"],version = ">=4.3.0"}
 django-celery-beat = "*"
 django-cors-headers = "*"
 pylibmc = "*"
+django-bmemcached = "*"
+python-binary-memcached = "*"
 
 [dev-packages]
 ipdb = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d648617b5d1de539bbed619319cc7155778820425cf04128f9bfe137bdb58bde"
+            "sha256": "3b7d0c3b7f34fadf54ce68976bd7786b953bb1f5715016a70b02174d1bb72060"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -41,18 +41,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:9d588e23a8f6bbb1c71790d70190f67bd644aaf6a6010ffed40d63c1f38d6b9d",
-                "sha256:d695bb99dec048800fcba9657182d2db3a4cae5e6c3625a5b3a5cd785fb2d6d6"
+                "sha256:03522d5b89fcf335a8bd606984e14915581aa487af4af6a0f4317e0251a069d4",
+                "sha256:30520dbf9165610aa3857141df87c63bef20e8255dec986fb0aaae6fe38ff336"
             ],
             "index": "pypi",
-            "version": "==1.9.224"
+            "version": "==1.9.226"
         },
         "botocore": {
             "hashes": [
-                "sha256:197f118419b81c8e15db03b92220f9fa864de2f062d962dbbe1a30d42d080d50",
-                "sha256:e2009cc78a99d284aa40d8bdc6954a47f2afeeecd33492ba8ef9337b97d0044c"
+                "sha256:8b393d00165880c7714b003953684166b4805074d657b3249cff25b688c0991c",
+                "sha256:b5867d757a29b18c57f48bb2f274e193e5f27414fa6234b2e55348b266b87611"
             ],
-            "version": "==1.12.224"
+            "version": "==1.12.226"
         },
         "celery": {
             "extras": [
@@ -95,6 +95,13 @@
             "index": "pypi",
             "version": "==2.2.5"
         },
+        "django-bmemcached": {
+            "hashes": [
+                "sha256:a1f6183b9f9ed0959336ced11ae52506ef322a18dde3f4884b5ec8982b02bb3f"
+            ],
+            "index": "pypi",
+            "version": "==0.2.4"
+        },
         "django-celery-beat": {
             "hashes": [
                 "sha256:61c92d4b600a9f24406ee0b8d01a9b192253e15d047e3325e1d81e2cacf7aba6",
@@ -121,11 +128,11 @@
         },
         "django-countries": {
             "hashes": [
-                "sha256:73476e80877936e072cf0935109590def986d528083c9c1a99c0291f68f7d08a",
-                "sha256:fdcbbd6cd4740614e07b48f30714a57b95033913108d4a878b5ac73dbf3708e0"
+                "sha256:1cefad9ec804d6a0318b91c5394b5aef00336755928f44d0a6420507719d65c8",
+                "sha256:22e96236101783cfe5222ef5174972242a7e8176336d119a4dc111aedce35897"
             ],
             "index": "pypi",
-            "version": "==5.4"
+            "version": "==5.5"
         },
         "django-filter": {
             "hashes": [
@@ -153,11 +160,11 @@
         },
         "django-storages": {
             "hashes": [
-                "sha256:8e35d2c7baeda5dc6f0b4f9a0fc142d25f9a1bf72b8cebfcbc5db4863abc552d",
-                "sha256:b1a63cd5ea286ee5a9fb45de6c3c5c0ae132d58308d06f1ce9865cfcd5e470a7"
+                "sha256:87287b7ad2e789cd603373439994e1ac6f94d9dc2e5f8173d2a87aa3ed458bd9",
+                "sha256:f3b3def96493d3ccde37b864cea376472baf6e8a596504b209278801c510b807"
             ],
             "index": "pypi",
-            "version": "==1.7.1"
+            "version": "==1.7.2"
         },
         "django-timezone-field": {
             "hashes": [
@@ -208,10 +215,10 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:9ff1b1c5a354142de080b8a4e9803e5d0d59283c93aed808617c787d16768375",
-                "sha256:b7143592e374e50584564794fcb8aaf00a23025f9db866627f89a21491847a8d"
+                "sha256:0c505102757e7fa28b9f0958d8bc81301159dea16e2649858c92edc158b78a83",
+                "sha256:9a9f75ce32e78170905888acbf2376a81d3f21ecb3bb4867050413411d3ca7a9"
             ],
-            "version": "==0.20"
+            "version": "==0.21"
         },
         "jmespath": {
             "hashes": [
@@ -330,6 +337,13 @@
             "index": "pypi",
             "version": "==1.6.1"
         },
+        "python-binary-memcached": {
+            "hashes": [
+                "sha256:8cc4e71c20a2d9e75c30669c4bef35ee407bbfc72a631fc7ad130a2957bd1ed1"
+            ],
+            "index": "pypi",
+            "version": "==0.28.0"
+        },
         "python-crontab": {
             "hashes": [
                 "sha256:11488bbac026bf77a659fee0bf8e20de9651753ad0fdf6649237e3b9e04b866a"
@@ -394,6 +408,20 @@
                 "sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873"
             ],
             "version": "==0.3.0"
+        },
+        "typing": {
+            "hashes": [
+                "sha256:91dfe6f3f706ee8cc32d38edbbf304e9b7583fb37108fef38229617f8b3eba23",
+                "sha256:c8cabb5ab8945cd2f54917be357d134db9cc1eb039e59d1606dc1e60cb1d9d36",
+                "sha256:f38d83c5a7a7086543a0f649564d661859c5146a85775ab90c0d2f93ffaa9714"
+            ],
+            "version": "==3.7.4.1"
+        },
+        "uhashring": {
+            "hashes": [
+                "sha256:7bedeef34a0e1df21f7d4396c6657f9a2a0cfb0ce9f77bc18e06df7e28eecebe"
+            ],
+            "version": "==1.1"
         },
         "urllib3": {
             "hashes": [

--- a/hsv_dot_beer/config/production.py
+++ b/hsv_dot_beer/config/production.py
@@ -15,7 +15,7 @@ def get_cache():
         }
     return {
       'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
+        'BACKEND': 'django_bmemcached.memcached.BMemcached',
         # TIMEOUT is not the connection timeout! It's the default
         # expiration
         # timeout that should be applied to keys! Setting it to `None`


### PR DESCRIPTION
@doismellburning seems to have stumbled upon a fix in
https://github.com/doismellburning/emporium/commit/14f88931b4ccbc5c43ee62823dd3eaabebe1cdd9
so let's go with that.