### PR TITLE
Fix Twitter threading

### DIFF
--- a/tap_list_providers/tasks.py
+++ b/tap_list_providers/tasks.py
@@ -239,7 +239,11 @@ def test_tweet(self):
         access_token_key=access_key,
         access_token_secret=access_secret,
     )
-    message = 'Hello World! I know nothing.\r\nThis should be on line two.'
+    message = 'This is a test long tweet\r\n{}'.format(
+        '\r\n'.join(
+            f'This is line {line}' for line in range(2, 30)
+        )
+    )
     try:
         if calc_expected_status_length(message) > CHARACTER_LIMIT:
             api.PostUpdates(message, continuation='…', threaded=True)

--- a/tap_list_providers/tasks.py
+++ b/tap_list_providers/tasks.py
@@ -9,7 +9,7 @@ from django.db.models import Prefetch
 from django.utils.timezone import now
 from requests.exceptions import RequestException
 from celery import shared_task
-from twitter.api import Api, CHARACTER_LIMIT
+from twitter.api import CHARACTER_LIMIT
 from twitter.error import TwitterError
 from twitter.twitter_utils import calc_expected_status_length
 
@@ -20,6 +20,7 @@ from tap_list_providers.base import BaseTapListProvider
 from tap_list_providers.parsers import (  # noqa
     digitalpour, taphunter, untappd, stemandstein, taplist_io,
 )
+from tap_list_providers.twitter_api import ThreadedApi
 
 SINGLE_BEER_TEMPLATE = "We found a new beer! {} from {} (style: {}) on tap at {}"
 
@@ -137,7 +138,7 @@ def tweet_about_beers(self, beer_pks):
     ):
         LOG.warning('Twitter API credentials not set!')
         return
-    api = Api(
+    api = ThreadedApi(
         consumer_key=consumer_key,
         consumer_secret=consumer_secret,
         access_token_key=access_key,
@@ -194,7 +195,7 @@ def tweet_about_beers(self, beer_pks):
 
     try:
         if calc_expected_status_length(message) > CHARACTER_LIMIT:
-            api.PostUpdates(message, continuation='…')
+            api.PostUpdates(message, continuation='…', threaded=True)
         else:
             api.PostUpdate(message)
     except TwitterError as exc:
@@ -232,7 +233,7 @@ def test_tweet(self):
     ):
         LOG.warning('Twitter API credentials not set!')
         return
-    api = Api(
+    api = ThreadedApi(
         consumer_key=consumer_key,
         consumer_secret=consumer_secret,
         access_token_key=access_key,
@@ -241,7 +242,7 @@ def test_tweet(self):
     message = 'Hello World! I know nothing.\r\nThis should be on line two.'
     try:
         if calc_expected_status_length(message) > CHARACTER_LIMIT:
-            api.PostUpdates(message, continuation='…')
+            api.PostUpdates(message, continuation='…', threaded=True)
         else:
             api.PostUpdate(message)
     except TwitterError as exc:

--- a/tap_list_providers/test/test_tweets.py
+++ b/tap_list_providers/test/test_tweets.py
@@ -37,7 +37,7 @@ class TweetTestCase(TestCase):
             TWITTER_ACCESS_TOKEN_SECRET=self.api_secret,
         )
 
-    @patch('tap_list_providers.tasks.Api')
+    @patch('tap_list_providers.tasks.ThreadedApi')
     @patch.object(Task, 'retry')
     def test_single_beer(self, mock_retry, mock_api):
         beer = BeerFactory()
@@ -61,7 +61,7 @@ class TweetTestCase(TestCase):
         )
         mock_api.return_value.PostUpdates.assert_not_called()
 
-    @patch('tap_list_providers.tasks.Api')
+    @patch('tap_list_providers.tasks.ThreadedApi')
     @patch.object(Task, 'retry')
     def test_single_beer_no_twitter(self, mock_retry, mock_api):
         beer = BeerFactory()
@@ -87,7 +87,7 @@ class TweetTestCase(TestCase):
         )
         mock_api.return_value.PostUpdates.assert_not_called()
 
-    @patch('tap_list_providers.tasks.Api')
+    @patch('tap_list_providers.tasks.ThreadedApi')
     @patch.object(Task, 'retry')
     def test_single_beer_venue_twitter(self, mock_retry, mock_api):
         beer = BeerFactory()
@@ -113,7 +113,7 @@ class TweetTestCase(TestCase):
         )
         mock_api.return_value.PostUpdates.assert_not_called()
 
-    @patch('tap_list_providers.tasks.Api')
+    @patch('tap_list_providers.tasks.ThreadedApi')
     @patch.object(Task, 'retry')
     def test_single_beer_already_tweeted(self, mock_retry, mock_api):
         beer = BeerFactory(tweeted_about=True)
@@ -130,7 +130,7 @@ class TweetTestCase(TestCase):
         mock_api.return_value.PostUpdate.assert_not_called()
         mock_api.return_value.PostUpdates.assert_not_called()
 
-    @patch('tap_list_providers.tasks.Api')
+    @patch('tap_list_providers.tasks.ThreadedApi')
     @patch.object(Task, 'retry')
     def test_single_beer_no_creds(self, mock_retry, mock_api):
         beer = BeerFactory()
@@ -145,7 +145,7 @@ class TweetTestCase(TestCase):
         mock_retry.assert_not_called()
         mock_api.assert_not_called()
 
-    @patch('tap_list_providers.tasks.Api')
+    @patch('tap_list_providers.tasks.ThreadedApi')
     @patch.object(Task, 'retry')
     def test_multi_beer(self, mock_retry, mock_api):
         mfg = ManufacturerFactory()
@@ -168,7 +168,7 @@ class TweetTestCase(TestCase):
         mock_api.return_value.PostUpdates.assert_called_once()
         mock_api.return_value.PostUpdate.assert_not_called()
         call_args = mock_api.return_value.PostUpdates.call_args
-        self.assertEqual(call_args[1], {'continuation': '…'})
+        self.assertEqual(call_args[1], {'continuation': '…', 'threaded': True})
         self.assertEqual(len(call_args[0]), 1)
         tweet = call_args[0][0]
         self.assertIn(
@@ -185,7 +185,7 @@ class TweetTestCase(TestCase):
                 self.venue.name,
             ), line)
 
-    @patch('tap_list_providers.tasks.Api')
+    @patch('tap_list_providers.tasks.ThreadedApi')
     @patch.object(Task, 'retry')
     def test_multi_beer_more_to_come(self, mock_retry, mock_api):
         mfg = ManufacturerFactory()
@@ -209,7 +209,7 @@ class TweetTestCase(TestCase):
         mock_api.return_value.PostUpdates.assert_called_once()
         mock_api.return_value.PostUpdate.assert_not_called()
         call_args = mock_api.return_value.PostUpdates.call_args
-        self.assertEqual(call_args[1], {'continuation': '…'})
+        self.assertEqual(call_args[1], {'continuation': '…', 'threaded': True})
         self.assertEqual(len(call_args[0]), 1)
         tweet = call_args[0][0]
         self.assertIn(
@@ -226,7 +226,7 @@ class TweetTestCase(TestCase):
                 self.venue.name,
             ), line)
 
-    @patch('tap_list_providers.tasks.Api')
+    @patch('tap_list_providers.tasks.ThreadedApi')
     def test_beer_not_found_yet(self, mock_api):
         beer_pks = [1234, 5678]
         with self.settings_context_manager():

--- a/tap_list_providers/test/test_twitter_api.py
+++ b/tap_list_providers/test/test_twitter_api.py
@@ -1,0 +1,79 @@
+from itertools import count
+from random import SystemRandom
+from string import ascii_lowercase
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from tap_list_providers.twitter_api import ThreadedApi
+
+FAKE_ID = count(1)
+
+
+class FakeStatus():
+
+    def __init__(self):
+        self.id = next(FAKE_ID)
+
+
+class TestThreadedApi(TestCase):
+
+    def setUp(self):
+        self.rng = SystemRandom()
+        self.api = ThreadedApi()
+        self.fake_last_status = None
+        # just silence the config check
+        # pylint: disable=protected-access
+        self.api._config = True
+
+    def test_single_tweet(self):
+        msg = 'This is a short message'
+        with patch.object(self.api, 'PostUpdate') as mock_post_update:
+            self.api.PostUpdates(msg)
+            mock_post_update.assert_called_once_with(status=msg)
+
+    def test_long_tweet(self):
+
+        words = [
+            ''.join(self.rng.choices(ascii_lowercase, k=25))
+            for dummy in range(25)
+        ]
+        msg = ' '.join(words)
+
+        def get_fake_id(status, in_reply_to_status_id=None):
+            if not self.fake_last_status:
+                self.assertIsNone(in_reply_to_status_id)
+            else:
+                self.assertEqual(in_reply_to_status_id, self.fake_last_status.id)
+
+            self.assertIn(status, msg)
+            next_status = FakeStatus()
+            self.fake_last_status = next_status
+            return next_status
+
+        with patch.object(self.api, 'PostUpdate') as mock_post_update:
+            mock_post_update.side_effect = get_fake_id
+            self.api.PostUpdates(msg, threaded=True)
+            calls = mock_post_update.call_args_list
+        # 625 chars + 50 spaces ==> 3 tweets
+        self.assertEqual(len(calls), 3)
+
+    def test_long_tweet_no_thread(self):
+        words = [
+            ''.join(self.rng.choices(ascii_lowercase, k=25))
+            for dummy in range(25)
+        ]
+        msg = ' '.join(words)
+
+        def get_fake_id(status):
+            self.assertIn(status, msg)
+            next_status = FakeStatus()
+            self.fake_last_status = next_status
+            return next_status
+
+        with patch.object(self.api, 'PostUpdate') as mock_post_update:
+            mock_post_update.side_effect = get_fake_id
+            self.api.PostUpdates(msg, threaded=False)
+            calls = mock_post_update.call_args_list
+        # 625 chars + 50 spaces ==> 3 tweets
+        self.assertEqual(len(calls), 3)

--- a/tap_list_providers/twitter_api.py
+++ b/tap_list_providers/twitter_api.py
@@ -1,0 +1,55 @@
+from twitter.api import Api, CHARACTER_LIMIT
+
+
+class ThreadedApi(Api):
+
+    def PostUpdates(
+        self, status, continuation=None, threaded=False, **kwargs
+    ):
+        """Post one or more twitter status messages from the authenticated user.
+        Unlike api.PostUpdate, this method will post multiple status updates
+        if the message is longer than CHARACTER_LIMIT characters.
+        Args:
+          status:
+            The message text to be posted.
+            May be longer than CHARACTER_LIMIT characters.
+          continuation:
+            The character string, if any, to be appended to all but the
+            last message.  Note that Twitter strips trailing '...' strings
+            from messages.  Consider using the unicode \u2026 character
+            (horizontal ellipsis) instead. [Defaults to None]
+          threaded:
+            If True, makes each additional status message a reply to the
+            previous one. [Defaults to False]
+          **kwargs:
+            See api.PostUpdate for a list of accepted parameters.
+        Returns:
+          A of list twitter.Status instance representing the messages posted.
+        """
+        results = list()
+
+        if continuation is None:
+            continuation = ''
+        char_limit = CHARACTER_LIMIT - len(continuation)
+
+        tweets = self._TweetTextWrap(status=status, char_lim=char_limit)
+
+        if len(tweets) == 1:
+            results.append(self.PostUpdate(status=tweets[0], **kwargs))
+            return results
+        last_reply_to_id = None
+        for tweet in tweets[0:-1]:
+            if threaded and last_reply_to_id is not None:
+                # use the not none check here so we don't override the caller
+                # if they're tweeting a series of updates in response to
+                # an existing status
+                kwargs['in_reply_to_status_id'] = last_reply_to_id
+            latest_tweet = self.PostUpdate(status=tweet + continuation, **kwargs)
+            last_reply_to_id = latest_tweet.id
+            results.append(latest_tweet)
+
+        if threaded:
+            kwargs['in_reply_to_status_id'] = last_reply_to_id
+        results.append(self.PostUpdate(status=tweets[-1], **kwargs))
+
+        return results


### PR DESCRIPTION
Subclass `twitter.api.Api` and override `PostUpdates()` to properly thread tweets.

Fixes #277.