### PR TITLE
Preserve line breaks when threading tweets

### DIFF
--- a/tap_list_providers/test/test_twitter_api.py
+++ b/tap_list_providers/test/test_twitter_api.py
@@ -2,6 +2,7 @@ from itertools import count
 from random import SystemRandom
 from string import ascii_lowercase
 
+from twitter.api import CHARACTER_LIMIT
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -91,11 +92,12 @@ class TestThreadedApi(TestCase):
             ' here because everything is awful. Enjoy Arby\'s.',
             'Line 5',
         ])
-        tweets = self.api.split_tweet_by_lines(tweet, continuation='…')
+        tweets = self.api.split_tweet_by_lines(
+            tweet, character_limit=CHARACTER_LIMIT - len('…'))
         self.assertEqual(len(tweets), 3, tweets)
         self.assertEqual(
             tweets[0],
-            'Line 1\r\nLine 2\r\nLine 3…',
+            'Line 1\r\nLine 2\r\nLine 3',
         )
         self.assertEqual(
             tweets[1],
@@ -104,7 +106,7 @@ class TestThreadedApi(TestCase):
             ' should be preserved as line 4 but who knows what Twitter will '
             'do. This needs even more filler since Twitter decided to double'
             ' its tweet character limit. I have no idea what else to put in '
-            'here because everything…'
+            'here because everything'
         )
         self.assertEqual(
             tweets[2],


### PR DESCRIPTION
Fixes #280 by rewriting the way we preserve line breaks:

1. Split the tweet up by lines.
2. If a given line is too long to fit in a single tweet, take whatever we've accrued so far and save that as a tweet, then pass the given line to upstream's split by whitespace, then drop whatever it gives us into the series of tweets (after appending continuation to each line).
3. If the accrued current tweet plus the given line is too long, save the accrued tweet plus continuation to the series of tweets and then keep the given line as the start of the next tweet.
4. Otherwise, append a line break to the accrued tweet followed by the given line.

Once done looping over the lines, save the accrued tweet as the last one.