### PR TITLE
Drop unneeded model from scheduled tasks fixture

### DIFF
--- a/tap_list_providers/fixtures/scheduled_tasks.json
+++ b/tap_list_providers/fixtures/scheduled_tasks.json
@@ -1,12 +1,5 @@
 [
 {
-  "model": "django_celery_beat.periodictasks",
-  "pk": 1,
-  "fields": {
-    "last_update": "2020-01-15T21:04:30.924Z"
-  }
-},
-{
   "model": "django_celery_beat.periodictask",
   "pk": 1,
   "fields": {


### PR DESCRIPTION
All it does is cause integrity errors