### PR TITLE
Downgrade django-bmemcached to 0.2.4

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -28,7 +28,7 @@ celery = {extras = ["redis"],version = ">=4.3.0"}
 django-celery-beat = "*"
 django-cors-headers = "*"
 pylibmc = "*"
-django-bmemcached = "*"
+django-bmemcached = "<0.3.0"
 python-binary-memcached = "*"
 python-twitter = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "22dd413b11b8b26ac066dc0a8cd1f026dc7c4760ca782817df76ace2ae64ac62"
+            "sha256": "d45adc718093ee67717b1836b26e5fa8cee47f7d5d7a027d450acacc0cd68b85"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -48,18 +48,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:589675488d3d42783098321619ddf7a8ec06dd11e9b73db19deb063cfb05eec6",
-                "sha256:c8cc6d8d5474e46f0826ba1156356c583961c2df8c4324f4373df7a83bbce627"
+                "sha256:7aaccacc199cd633b5ac14f0d544c9d592c53275a79cf4d230a9f66215331665",
+                "sha256:ca36aabfa5e7fa9ee8f84f82c3faffb4ffe078923f935f572f70dc49154ef6a0"
             ],
             "index": "pypi",
-            "version": "==1.11.4"
+            "version": "==1.11.5"
         },
         "botocore": {
             "hashes": [
-                "sha256:91a39d0ede1676c22cf6158bbbc4f85cc3385ab9201b5190c25e3770967f94c0",
-                "sha256:cf29118fb62513712888f2f3dd337c0933a3e253b952f0bbe6d8d4c4fd4be5be"
+                "sha256:96a16e64c96d34fa2e535c1d5a0024bf55eee853b939be0331318cd060b3d395",
+                "sha256:f0feffde6e1312c6361a96e24385a58889683a3d6a007be4d4804bc209384b3f"
             ],
-            "version": "==1.14.4"
+            "version": "==1.14.5"
         },
         "celery": {
             "extras": [
@@ -104,10 +104,10 @@
         },
         "django-bmemcached": {
             "hashes": [
-                "sha256:4e4b7d97216dbae331c1de10e699ca22804b94ec3a90d2762dd5d146e6986a8a"
+                "sha256:a1f6183b9f9ed0959336ced11ae52506ef322a18dde3f4884b5ec8982b02bb3f"
             ],
             "index": "pypi",
-            "version": "==0.3.0"
+            "version": "==0.2.4"
         },
         "django-celery-beat": {
             "hashes": [
@@ -489,14 +489,6 @@
         }
     },
     "develop": {
-        "appnope": {
-            "hashes": [
-                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
-                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
-            ],
-            "markers": "sys_platform == 'darwin'",
-            "version": "==0.1.0"
-        },
         "astroid": {
             "hashes": [
                 "sha256:71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a",


### PR DESCRIPTION
They changed the syntax between 0.2.4 and 0.3.0 in a breaking
manner, so temporarily downgrade while I investigate the fix.