### PR TITLE
Strip stray backslashes from Untappd

### DIFF
--- a/tap_list_providers/parsers/untappd.py
+++ b/tap_list_providers/parsers/untappd.py
@@ -201,8 +201,8 @@ class UntappdParser(BaseTapListProvider):
         else:
             return int(size.split('oz')[0])
 
-    def parse_price(self, price):
-        price = price.replace('$', '')
+    def parse_price(self, price: str) -> float:
+        price = price.replace('$', '').strip().replace('\\', '')
         return float(price)
 
     def parse_pricing(self, entry):


### PR DESCRIPTION
This seems to be relatively new, but Untappd is escaping dollar signs.

Formal testing to come later; I wanted to get this out because we missed Black is Beautiful from YH.