### PR TITLE
Prevent URLs from sneaking in as Twitter handles

### DIFF
--- a/tap_list_providers/base.py
+++ b/tap_list_providers/base.py
@@ -37,6 +37,9 @@ COMMON_BREWERY_ENDINGS = (
     'Beer',
     'Beer Co.',
     'Craft Brewery',
+    'Brewing Co',
+    'Beer Co',
+    'Brewing Company™',
 )
 
 REPLACE_TARGET = '\\.'
@@ -380,7 +383,7 @@ class BaseTapListProvider():
                     raise
         return beer
 
-    def get_manufacturer(self, name, **defaults):
+    def get_manufacturer(self, name: str, **defaults) -> Manufacturer:
         name = ENDINGS_REGEX.sub('', name.strip()).strip()
         field_names = {i.name for i in Manufacturer._meta.fields}
         bogus_defaults = set(defaults).difference(field_names)
@@ -434,6 +437,12 @@ class BaseTapListProvider():
                     # don't touch name
                     continue
                 saved_value = getattr(manufacturer, field)
+                if field == 'twitter_handle':
+                    if value and '/' in value:
+                        if value.endswith('/'):
+                            value = value.split('/')[-2]
+                        else:
+                            value = value.split('/')[-1]
                 if saved_value != value:
                     setattr(manufacturer, field, value)
                     needs_update = True

--- a/tap_list_providers/base.py
+++ b/tap_list_providers/base.py
@@ -169,7 +169,7 @@ class BaseTapListProvider():
             'get_beer(): name %s, mfg %s, defaults %s',
             name, manufacturer, defaults,
         )
-        mfg_name = manufacturer.name
+        mfg_name = manufacturer.name.replace('™', '').replace('®', '')
         for ending in COMMON_BREWERY_ENDINGS:
             if mfg_name.endswith(ending):
                 mfg_name = mfg_name.replace(ending, '').strip()
@@ -384,6 +384,8 @@ class BaseTapListProvider():
         return beer
 
     def get_manufacturer(self, name: str, **defaults) -> Manufacturer:
+        name = name.replace('™', '')
+        name = name.replace('®', '')
         name = ENDINGS_REGEX.sub('', name.strip()).strip()
         field_names = {i.name for i in Manufacturer._meta.fields}
         bogus_defaults = set(defaults).difference(field_names)

--- a/tap_list_providers/test/test_base.py
+++ b/tap_list_providers/test/test_base.py
@@ -1,11 +1,12 @@
-from unittest import TestCase
+from django.test import TestCase
+from unittest import TestCase as UnittestTestCase
 
 from tap_list_providers.base import fix_urls, BaseTapListProvider
 from beers.test.factories import ManufacturerFactory, StyleFactory
 from beers.models import Manufacturer, ManufacturerAlternateName
 
 
-class URLFixTestCase(TestCase):
+class URLFixTestCase(UnittestTestCase):
 
     def test_fix_urls(self):
         bad_data = {
@@ -45,6 +46,19 @@ class ManufacturerTestCase(TestCase):
         provider = BaseTapListProvider()
         looked_up = provider.get_manufacturer(name=mfg.name)
         self.assertEqual(looked_up, mfg)
+
+
+class TwitterHandleTestCase(TestCase):
+
+    def test_twitter_handle(self):
+        mfg = ManufacturerFactory(twitter_handle='abc123')
+        provider = BaseTapListProvider()
+        looked_up = provider.get_manufacturer(
+            name=mfg.name,
+            twitter_handle='https://twitter.com/foobar',
+        )
+        self.assertEqual(looked_up, mfg)
+        self.assertEqual(looked_up.twitter_handle, 'foobar')
 
 
 class StyleTestCase(TestCase):


### PR DESCRIPTION
Also add some more common brewery endings and strip ® and ™ from brewery names (looking at you, Rocket Republic).

Fixes #336.