### PR TITLE
Fix the case where stripping out the brewery name breaks the beer

### DIFF
--- a/tap_list_providers/base.py
+++ b/tap_list_providers/base.py
@@ -123,6 +123,9 @@ class BaseTapListProvider():
         """Try to strip the manufacturer name if possible"""
         original_name = name.strip()
         name = name.replace(mfg_name, '').strip()
+        if name.startswith(COMMON_BREWERY_ENDINGS):
+            for ending in COMMON_BREWERY_ENDINGS:
+                name = name.replace(ending, '').strip()
         if name.startswith(tuple('/-_')):
             # it's likely a collaboration beer. Put the manufacturer back in there.
             name = original_name

--- a/tap_list_providers/test/test_base.py
+++ b/tap_list_providers/test/test_base.py
@@ -83,3 +83,8 @@ class FixBeerNameTestCase(TestCase):
         provider = BaseTapListProvider()
         name = provider.reformat_beer_name('Hi-Wire / New Belgium Belgian Stout', 'Hi-Wire')
         self.assertEqual(name, 'Hi-Wire / New Belgium Belgian Stout')
+
+    def test_yazoo(self):
+        provider = BaseTapListProvider()
+        name = provider.reformat_beer_name('Yazoo Brewing Company Hefeweizen', 'Yazoo')
+        self.assertEqual(name, 'Hefeweizen')


### PR DESCRIPTION
So that way `Yazoo Brewing Company Hefeweizen` with brewery `Yazoo`
doesn't become `Brewing Company Hefeweizen`.

Fixes #325