### PR TITLE
Create a test for ensuring that we didn't forget to commit migrations

### DIFF
--- a/hsv_dot_beer/test_migration_missing.py
+++ b/hsv_dot_beer/test_migration_missing.py
@@ -3,7 +3,6 @@ from django.core.management import call_command
 
 
 class TestMissingMigrations(TestCase):
-
     def test_for_missing_migrations(self):
         """Check to see if we're missing migrations in the committed code.
 

--- a/hsv_dot_beer/test_migration_missing.py
+++ b/hsv_dot_beer/test_migration_missing.py
@@ -1,0 +1,20 @@
+from django.test import TestCase
+from django.core.management import call_command
+
+
+class TestMissingMigrations(TestCase):
+
+    def test_for_missing_migrations(self):
+        """Check to see if we're missing migrations in the committed code.
+
+        If no migrations are detected as needed, `result` will be `None`.
+        In all other cases, the call will raise a SystemExit, alerting your
+        team that someone is trying to make a change that requires a migration
+        and that migration is absent.
+
+        Adapted from:
+        http://blog.birdhouse.org/2020/11/19/django-testing-for-missing-migrations/
+        """
+
+        result = call_command("makemigrations", check=True, dry_run=True)
+        self.assertIsNone(result)


### PR DESCRIPTION
This way stuff like #366 won't have to happen and we'll catch during test/review.