### PR TITLE
Raise a request exception on digitalpour outages

### DIFF
--- a/tap_list_providers/parsers/digitalpour.py
+++ b/tap_list_providers/parsers/digitalpour.py
@@ -310,7 +310,9 @@ class DigitalPourParser(BaseTapListProvider):
 
     def fetch(self):
         """Fetch the most recent taplist"""
-        data = requests.get(self.url).json()
+        response = requests.get(self.url)
+        response.raise_for_status()
+        data = response.json()
         return data
 
     def taps(self):


### PR DESCRIPTION
DigitalPour is currently down (503 error), so let's raise the right
exception in that case.