### PR TITLE
Fix scheduled parsing for Arryved POS Menus

### DIFF
--- a/tap_list_providers/base.py
+++ b/tap_list_providers/base.py
@@ -69,7 +69,7 @@ class BaseTapListProvider:
         try:
             return subclasses[provider_name]
         except KeyError:
-            raise ValueError(f"Unknown prover name {provider_name}")
+            raise ValueError(f"Unknown provider name {provider_name}")
 
     def get_venues(self):
         if not self.provider_name:

--- a/tap_list_providers/tasks.py
+++ b/tap_list_providers/tasks.py
@@ -26,6 +26,7 @@ from tap_list_providers.parsers import (  # noqa
     taplist_io,
     beermenus,
     arryved_menu,
+    arryved_pos,
 )
 from tap_list_providers.twitter_api import ThreadedApi
 


### PR DESCRIPTION
1. Adds `arryved_pos` to the imports in `tap_list_providers/tasks.py` so the subclass logic can find this parser.
2. Fix typo (prover -> provider)