### PR TITLE
Drop wine serving sizes from Tallulah fixture

### DIFF
--- a/tap_list_providers/parsers/arryved_menu.py
+++ b/tap_list_providers/parsers/arryved_menu.py
@@ -115,6 +115,11 @@ class ArryvedMenuParser(BaseTapListProvider):
             if beer["last_updated"] > last_updated:
                 last_updated = beer["last_updated"]
             tap_number += 1
+        delete_result = Tap.objects.filter(
+            venue=venue,
+            tap_number__gte=tap_number,
+        ).delete()
+        LOG.debug("Deleted %s extra taps", delete_result[0])
         BeerPrice.objects.bulk_create(prices)
         self.check_timestamp = last_updated
         return last_updated

--- a/tap_list_providers/test/test_arryved_menu.py
+++ b/tap_list_providers/test/test_arryved_menu.py
@@ -34,11 +34,8 @@ class CommandsTestCase(TestCase):
                 "TAS",
                 "32O",
                 "64O",
-                "win",
                 "13O",
                 "PIN",
-                "POU",
-                "WIN",
             ],
         )
         with open(
@@ -66,8 +63,8 @@ class CommandsTestCase(TestCase):
             opts = {}
             call_command("parsearryvedmenu", *args, **opts)
             self.assertEqual(Manufacturer.objects.count(), 1)
-            self.assertEqual(Tap.objects.count(), 22)
-            self.assertEqual(Beer.objects.count(), 22)
+            self.assertEqual(Tap.objects.count(), 16)
+            self.assertEqual(Beer.objects.count(), 16)
             for tap in Tap.objects.all():
                 self.assertEqual(tap.time_updated.year, 2020)
             tap = Tap.objects.select_related("beer").get(tap_number=2)

--- a/venues/fixtures-al/venues.json
+++ b/venues/fixtures-al/venues.json
@@ -780,7 +780,7 @@
             "arryved_location_id": "BUUoDf5m",
             "arryved_menu_id": "BawA45BHSgQgzmo2",
             "arryved_manufacturer_name": "Tallulah",
-            "arryved_serving_sizes": "[\"TAS\", \"32O\", \"64O\", \"win\", \"13O\", \"PIN\", \"POU\", \"WIN\"]",
+            "arryved_serving_sizes": "[\"TAS\", \"32O\", \"64O\", \"13O\", \"PIN\"]",
             "arryved_pos_menu_names": "[]"
         }
     },


### PR DESCRIPTION
Also clean up unused taps at the end of processing the venue.

Reduces tap count from 21 to 17 and there are zero wines on tap.