### PR TITLE
Fix line length check when splitting long tweets

### DIFF
--- a/tap_list_providers/test/test_twitter_api.py
+++ b/tap_list_providers/test/test_twitter_api.py
@@ -10,6 +10,16 @@ from tap_list_providers.twitter_api import ThreadedApi
 
 FAKE_ID = count(1)
 
+REAL_BREAKAGE = """We found 8 new beers!
+- Cucumber Lime Seltzer from Chandlers Ford (style: Hard Seltzer) on tap at Chandlers Ford Brewing
+- Cranberry Lemonade Seltzer from Chandlers Ford (style: Hard Seltzer) on tap at Chandlers Ford Brewing
+- Island Thai’mmm from Chandlers Ford (style: Japanese Rice Lager) on tap at Chandlers Ford Brewing
+- Nitro Stock Ale from Chandlers Ford (style: Old Ale) on tap at Chandlers Ford Brewing
+- Chai Milk Stout from Chandlers Ford (style: Milk Stout) on tap at Chandlers Ford Brewing
+- Pumpkin Pie Stout (Nitro) from Chandlers Ford (style: Other Stout) on tap at Chandlers Ford Brewing
+- Big Beach Gose from Chandlers Ford (style: Fruited Gose) on tap at Chandlers Ford Brewing
+- Brett Hazy Pale Ale from Chandlers Ford (style: Brett Beer) on tap at Chandlers Ford Brewing"""  # noqa
+
 
 class FakeStatus:
     def __init__(self):
@@ -30,6 +40,13 @@ class TestThreadedApi(TestCase):
         with patch.object(self.api, "PostUpdate") as mock_post_update:
             self.api.PostUpdates(msg)
             mock_post_update.assert_called_once_with(status=msg)
+
+    def test_chandlers_ford(self):
+        """Test that the Chandlers Ford beers don't cause breakage"""
+        split_tweets = self.api.split_tweet_by_lines(REAL_BREAKAGE, CHARACTER_LIMIT - 1)
+        self.assertEqual(len(split_tweets), 4)
+        for tweet in split_tweets:
+            self.assertLess(len(tweet), CHARACTER_LIMIT, tweet)
 
     def test_long_tweet(self):
 

--- a/tap_list_providers/twitter_api.py
+++ b/tap_list_providers/twitter_api.py
@@ -1,8 +1,13 @@
+from typing import List
+
 from twitter.api import Api, CHARACTER_LIMIT
+from twitter.models import Status
 
 
 class ThreadedApi(Api):
-    def PostUpdates(self, status, continuation=None, threaded=False, **kwargs):
+    def PostUpdates(
+        self, status: str, continuation: str = "", threaded: bool = False, **kwargs
+    ) -> List[Status]:
         """Post one or more twitter status messages from the authenticated user.
         Unlike api.PostUpdate, this method will post multiple status updates
         if the message is longer than CHARACTER_LIMIT characters.
@@ -25,8 +30,6 @@ class ThreadedApi(Api):
         """
         results = list()
 
-        if continuation is None:
-            continuation = ""
         char_limit = CHARACTER_LIMIT - len(continuation)
 
         tweets = self.split_tweet_by_lines(
@@ -54,7 +57,7 @@ class ThreadedApi(Api):
 
         return results
 
-    def split_tweet_by_lines(self, tweet, character_limit):
+    def split_tweet_by_lines(self, tweet: str, character_limit: int) -> List[str]:
         """Break the thread up by lines if possible"""
         lines = tweet.split("\r\n")
         tweets = []

--- a/tap_list_providers/twitter_api.py
+++ b/tap_list_providers/twitter_api.py
@@ -59,7 +59,7 @@ class ThreadedApi(Api):
 
     def split_tweet_by_lines(self, tweet: str, character_limit: int) -> List[str]:
         """Break the thread up by lines if possible"""
-        lines = tweet.split("\r\n")
+        lines = tweet.splitlines()
         tweets = []
         current_tweet = ""
 
@@ -78,17 +78,15 @@ class ThreadedApi(Api):
                 # keep the last line as the start of our next tweet
                 current_tweet = split[-1]
                 continue
-            if len(line) + len(current_tweet) >= character_limit:
+            potential_next_msg = f"{current_tweet}\r\n{line}" if current_tweet else line
+            if len(potential_next_msg) >= character_limit:
                 # next tweet!
                 if current_tweet:
                     tweets.append(current_tweet)
                 current_tweet = line
                 continue
             # add the next line to the currently being built tweet
-            if current_tweet:
-                current_tweet = f"{current_tweet}\r\n{line}"
-            else:
-                current_tweet = line
+            current_tweet = potential_next_msg
         if current_tweet:
             # if we have anything left over, tack it on!
             tweets.append(current_tweet)


### PR DESCRIPTION
If two messages being joined are 278-279 characters without the CRLF, the tweet building logic created invalid tweets because it didn't consider the line length in the validation.

Fixes #378