### PR TITLE
Set the default auto field type to AutoField

### DIFF
--- a/hsv_dot_beer/config/common.py
+++ b/hsv_dot_beer/config/common.py
@@ -243,6 +243,9 @@ class Common(Configuration):  # pylint: disable=no-init
         ),
     }
 
+    # Auto field (new in Django 3.2)
+    DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
     # Default Venue time zone
     DEFAULT_VENUE_TIME_ZONE = "America/Chicago"
 


### PR DESCRIPTION
Silences a warning introduced by Django 3.2. Fortunately, it doesn't require any migrations.

Fixes #426.